### PR TITLE
Fix: Correct IconSource type annotation in Metrics.tsx

### DIFF
--- a/app/components/Metrics.tsx
+++ b/app/components/Metrics.tsx
@@ -1,12 +1,12 @@
 // app/components/Metrics.tsx
 import React from "react";
-import { Card, Grid, Text, Icon, BlockStack } from "@shopify/polaris";
+import { Card, Grid, Text, Icon, BlockStack, type IconSource } from "@shopify/polaris";
 import { CartIcon, InventoryIcon } from "@shopify/polaris-icons";
 
 interface MetricItemProps {
   title: string;
   value: string | number;
-  iconSource: import type("@shopify/polaris").IconSource;
+  iconSource: IconSource;
   valueTone?: 'critical' | 'success' | 'subdued'; // Only valid tones for Polaris Text
   helpText?: string;
 }


### PR DESCRIPTION
This commit fixes a build error caused by an incorrect type annotation for `IconSource` in the `MetricItemProps` interface within `app/components/Metrics.tsx`.

The previous syntax `iconSource: import type("@shopify/polaris").IconSource;` was invalid.

The correction involves:
- Importing `IconSource` as a type directly from '@shopify/polaris' at the top of the file: `import { ..., type IconSource } from "@shopify/polaris";`
- Updating the interface to use the imported type directly: `iconSource: IconSource;`

This change has been verified by a successful `npm run build` command.