### PR TITLE
Here's a summary of the changes I've made:

### DIFF
--- a/app/routes/app.settings.tsx
+++ b/app/routes/app.settings.tsx
@@ -451,15 +451,5 @@ function formStateToFormData(formState: NotificationSettingsFormData, intent: st
 // Duplicate and broken JSX below this point. It is unreachable and causes syntax errors.
 // Reason: The file already returns from the main component and helper function above. The following code is a duplicate and should not exist in a valid React file.
 // If you want to keep for reference, it is commented out. Remove to resolve errors.
-/*
-            </Layout.Section>
-            <Layout.Section>
-                <Button submit variant="primary" fullWidth loading={isSaving} onClick={() => fetcher.submit(formStateToFormData(formState, 'saveSettings'), { method: 'post' })}>Save Settings</Button>
-            </Layout.Section>
-          </Layout>
-        </BlockStack>
-      </fetcher.Form>
-    </Page>
-  );
-*/
+
 // End of file

--- a/app/routes/app.warehouses.$warehouseId.edit.tsx
+++ b/app/routes/app.warehouses.$warehouseId.edit.tsx
@@ -144,7 +144,7 @@ export const action = async ({ request, params }: ActionFunctionArgs) => {
       data: {
         name: validatedName,
         location: validatedLocation,
-        ...(validatedShopifyLocationGid && validatedShopifyLocationGid !== "" ? { shopifyLocationGid: validatedShopifyLocationGid } : {}),
+        shopifyLocationGid: (validatedShopifyLocationGid === "" || validatedShopifyLocationGid === undefined) ? null : validatedShopifyLocationGid,
       },
     });
     return redirect("/app/warehouses");

--- a/app/routes/app.warehouses.new.tsx
+++ b/app/routes/app.warehouses.new.tsx
@@ -109,7 +109,7 @@ export const action = async ({ request }: ActionFunctionArgs) => {
         shopId: shop.id,
         name: validatedName,
         location: validatedLocation,
-        shopifyLocationGid: validatedShopifyLocationGid || "",
+        shopifyLocationGid: validatedShopifyLocationGid === "" ? null : validatedShopifyLocationGid,
       },
     });
     return redirect("/app/warehouses");


### PR DESCRIPTION
- **app/routes/app.settings.tsx:** I removed a redundant and unreachable JSX code block.
- **app/routes/app.warehouses.new.tsx:** I've adjusted the action function. Now, if you submit an empty string from the form (like when you select the "None" option), `shopifyLocationGid` will be stored as `null` in the database. This ensures that "not linked" is properly represented as `NULL`, which works better with Prisma's unique constraints for fields that can be empty.
- **app/routes/app.warehouses.$warehouseId.edit.tsx:** I've updated the action function here as well. It will now explicitly set `shopifyLocationGid` to `null` in the database if you submit an empty string. This allows you to clear a previously set Shopify location linkage.

Just a heads-up: You asked me to skip the database schema migration step that would align the live schema with `prisma/schema.prisma`. This might lead to some inconsistencies down the line that could require you to manually intervene.