### PR TITLE
Fix: Use correct ChartVerticalIcon for Analytics/Reports

### DIFF
--- a/app/components/AppLayout.tsx
+++ b/app/components/AppLayout.tsx
@@ -5,7 +5,7 @@ import {
   HomeIcon,
   ProductIcon, // Corrected from ProductsIcon
   SettingsIcon,
-  AnalyticsIcon,
+  ChartVerticalIcon, // Corrected from AnalyticsIcon
   NotificationIcon,
 } from '@shopify/polaris-icons';
 import { useLocation } from '@remix-run/react';
@@ -71,7 +71,7 @@ export const AppLayout: React.FC<AppLayoutProps> = ({ children }) => {
   const navigationItems = [
     { url: '/app', label: 'Dashboard', icon: HomeIcon, selected: location.pathname === '/app', },
     { url: '/app/products', label: 'Products', icon: ProductIcon, selected: location.pathname.startsWith('/app/products'), }, // Corrected from ProductsIcon
-    { url: '/app/reports', label: 'Reports', icon: AnalyticsIcon, selected: location.pathname === '/app/reports', },
+    { url: '/app/reports', label: 'Reports', icon: ChartVerticalIcon, selected: location.pathname === '/app/reports', }, // Corrected from AnalyticsIcon
     { url: '/app/alerts', label: 'Alerts', icon: NotificationIcon, selected: location.pathname === '/app/alerts', },
     { url: '/app/settings', label: 'Settings', icon: SettingsIcon, selected: location.pathname === '/app/settings', },
   ];


### PR DESCRIPTION
Continuing to fix icon export errors from `@shopify/polaris-icons`. The Vercel build was failing because `AnalyticsIcon` is not a valid export. This commit changes the import and usage in `app/components/AppLayout.tsx` to `ChartVerticalIcon`, which is a suitable replacement for the 'Reports' navigation link.

Proactively verified that other icons (`HomeIcon`, `SettingsIcon`, `NotificationIcon`) used in the same component are correctly named and exported.