### PR TITLE
chore: run `prisma generate` before build to fix Vercel Prisma Client…

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "app",
   "private": true,
   "scripts": {
-    "build": "remix vite:build",
+    "build": "prisma generate && remix vite:build",
     "dev": "shopify app dev",
     "config:link": "shopify app config link",
     "generate": "shopify app generate",


### PR DESCRIPTION
… caching issue

Ensures Prisma Client is regenerated during the Vercel build process by adding `prisma generate` to the `build` script in `package.json`. This resolves potential issues caused by Vercel's dependency caching leading to an outdated Prisma Client.