### PR TITLE
chore: add diagnostic logging for Shopify env vars

### DIFF
--- a/app/shopify.server.ts
+++ b/app/shopify.server.ts
@@ -1,4 +1,13 @@
 import "@shopify/shopify-app-remix/adapters/node";
+
+// --- BEGIN DIAGNOSTIC LOGGING ---
+console.log("[DIAGNOSTIC] SHOPIFY_API_KEY:", process.env.SHOPIFY_API_KEY, "| TYPE:", typeof process.env.SHOPIFY_API_KEY);
+console.log("[DIAGNOSTIC] SHOPIFY_API_SECRET:", process.env.SHOPIFY_API_SECRET ? "SET" : "NOT SET", "| TYPE:", typeof process.env.SHOPIFY_API_SECRET); // Avoid logging secret directly
+console.log("[DIAGNOSTIC] SCOPES:", process.env.SCOPES, "| TYPE:", typeof process.env.SCOPES);
+console.log("[DIAGNOSTIC] SHOPIFY_APP_URL:", process.env.SHOPIFY_APP_URL, "| TYPE:", typeof process.env.SHOPIFY_APP_URL);
+console.log("[DIAGNOSTIC] SHOP_CUSTOM_DOMAIN:", process.env.SHOP_CUSTOM_DOMAIN, "| TYPE:", typeof process.env.SHOP_CUSTOM_DOMAIN);
+// --- END DIAGNOSTIC LOGGING ---
+
 import {
   AppDistribution,
   DeliveryMethod,


### PR DESCRIPTION
Adds console.log statements in `app/shopify.server.ts` to output the type and value of key Shopify-related environment variables at runtime. This is for diagnosing an issue where an `/[object%20Object]` error occurs during the Shopify login flow.