### PR TITLE
fix: explicitly set disabled=false on login form fields

### DIFF
--- a/app/routes/auth.login/route.tsx
+++ b/app/routes/auth.login/route.tsx
@@ -84,8 +84,9 @@ export default function AuthLoginPage() {
                       placeholder="your-store.myshopify.com"
                       autoComplete="on"
                       error={shopError} // Display error for the shop field
+                      disabled={false} // Explicitly set disabled to false
                     />
-                    <Button submit variant="primary" fullWidth>Log in</Button>
+                    <Button submit variant="primary" fullWidth disabled={false}>Log in</Button>
                   </FormLayout>
                 </Form>
                 {/* Display other general errors if any */}


### PR DESCRIPTION
Sets disabled={false} on the shop domain TextField and the submit Button in `app/routes/auth.login/route.tsx` as a measure to counteract any external factors that might be causing them to appear disabled.