### PR TITLE
feat: add shopify app deploy to Vercel build process

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,8 @@
   "name": "app",
   "private": true,
   "scripts": {
-    "build": "prisma generate && remix vite:build",
+    "shopify:deploy": "shopify app deploy --api-key $SHOPIFY_API_KEY --force",
+    "build": "npm run shopify:deploy && prisma generate && remix vite:build",
     "dev": "shopify app dev",
     "config:link": "shopify app config link",
     "generate": "shopify app generate",
@@ -56,7 +57,9 @@
     "jest": "^30.0.2",
     "prettier": "^3.2.4",
     "typescript": "^5.2.2",
-    "vite": "^6.2.2"
+    "vite": "^6.2.2",
+    "@shopify/cli": "^3.59.0",
+    "@shopify/app": "^3.59.0"
   },
   "workspaces": {
     "packages": [

--- a/shopify.app.toml
+++ b/shopify.app.toml
@@ -7,7 +7,7 @@ application_url = "https://pb-inventory-ai-olive.vercel.app/"
 embedded = true
 
 [webhooks]
-api_version = "2025-04"
+api_version = "2024-07"
 
   [[webhooks.subscriptions]]
   topics = [ "app/uninstalled" ]
@@ -19,7 +19,7 @@ api_version = "2025-04"
 
 [access_scopes]
 # Learn more at https://shopify.dev/docs/apps/tools/cli/configuration#access_scopes
-scopes = "write_products"
+scopes = "write_products,read_products,write_inventory,read_inventory,read_locations"
 
 [auth]
 redirect_urls = [


### PR DESCRIPTION
- Updates `shopify.app.toml` with corrected scopes and webhook API version.
- Adds `@shopify/cli` and `@shopify/app` to devDependencies.
- Modifies the build script in `package.json` to run `shopify app deploy --api-key $SHOPIFY_API_KEY --force` before the Remix build.

This ensures Shopify app configuration is synced during deployment, which is intended to resolve issues with outdated redirect URLs leading to `/[object Object]` errors.