### PR TITLE
fix: update shopify app deploy script and auth

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "app",
   "private": true,
   "scripts": {
-    "shopify:deploy": "shopify app deploy --api-key $SHOPIFY_API_KEY --force",
+    "shopify:deploy": "shopify app deploy --client-id $SHOPIFY_API_KEY --force",
     "build": "npm run shopify:deploy && prisma generate && remix vite:build",
     "dev": "shopify app dev",
     "config:link": "shopify app config link",


### PR DESCRIPTION
- Changes `shopify app deploy` flag from `--api-key` to `--client-id`.
- User has been instructed to set `SHOPIFY_API_KEY` (as client ID) and `SHOPIFY_CLI_TOKEN` (for non-interactive auth) environment variables in Vercel for the build process.