### PR TITLE
fix: add --verbose to shopify app deploy script

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "app",
   "private": true,
   "scripts": {
-    "shopify:deploy": "shopify app deploy --client-id $SHOPIFY_API_KEY --force",
+    "shopify:deploy": "shopify app deploy --client-id $SHOPIFY_API_KEY --force --verbose",
     "build": "npm run shopify:deploy && prisma generate && remix vite:build",
     "dev": "shopify app dev",
     "config:link": "shopify app config link",


### PR DESCRIPTION
Adds the --verbose flag to the `shopify app deploy` command in `package.json` to get more detailed output during Vercel builds, helping to diagnose persistent authentication issues.