### PR TITLE
fix: remove app/scopes_update webhook

### DIFF
--- a/shopify.app.toml
+++ b/shopify.app.toml
@@ -13,10 +13,6 @@ api_version = "2024-07"
   topics = [ "app/uninstalled" ]
   uri = "/webhooks/app/uninstalled"
 
-  [[webhooks.subscriptions]]
-  topics = [ "app/scopes_update" ]
-  uri = "/webhooks/app/scopes_update"
-
 [access_scopes]
 # Learn more at https://shopify.dev/docs/apps/tools/cli/configuration#access_scopes
 scopes = "write_products,read_products,write_inventory,read_inventory,read_locations"


### PR DESCRIPTION
Removes the webhook subscription for the `app/scopes_update` topic from `shopify.app.toml` as it is not compatible with API version 2024-07 and was causing `shopify app deploy` to fail.