### PR TITLE
Fix: Align Prisma queries with schema definitions

### DIFF
--- a/app/cron/dailyAnalysis.ts
+++ b/app/cron/dailyAnalysis.ts
@@ -14,7 +14,7 @@ export async function runDailyTasks() {
   const shops = await prisma.shop.findMany({
     // where: { accessToken: { not: null } }, // Original condition
     where: { initialSyncCompleted: true }, // Only run for shops that have completed the initial sync.
-    include: { notificationSettings: true },
+    include: { NotificationSettings: true },
   });
 
   if (shops.length === 0) {
@@ -28,7 +28,7 @@ export async function runDailyTasks() {
 
     // Fetch a valid offline session to perform API calls
     const offlineSessionRecord = await prisma.session.findFirst({
-      where: { shop: shop.shop, isOnline: false, accessToken: { not: null } },
+      where: { shop: { shop: shop.shop }, isOnline: false, accessToken: { not: null } },
       orderBy: { expires: 'desc' },
     });
 

--- a/app/routes/app.actions.send-alert-notification.tsx
+++ b/app/routes/app.actions.send-alert-notification.tsx
@@ -18,7 +18,7 @@ export const action = async ({ request }: ActionFunctionArgs) => {
   try {
     const shopRecord = await prisma.shop.findUnique({
       where: { shop: session.shop },
-      include: { notificationSettings: true },
+      include: { NotificationSettings: true },
     });
 
     if (!shopRecord) {

--- a/app/routes/app.settings.tsx
+++ b/app/routes/app.settings.tsx
@@ -57,7 +57,7 @@ export const loader = async ({ request }: LoaderFunctionArgs) => {
   const shopRecord = await prisma.shop.findUnique({ where: { shop: session.shop } });
   if (!shopRecord) throw new Response("Shop not found", { status: 404 });
 
-  const notificationSettings = await prisma.notificationSettings.findUnique({
+  const notificationSettings = await prisma.NotificationSetting.findUnique({
     where: { shopId: shopRecord.id },
   });
 
@@ -142,7 +142,7 @@ export const action = async ({ request }: ActionFunctionArgs) => {
 
     // Upsert NotificationSettings
     const { shopLowStockThreshold, ...notificationSpecificData } = dataToSave; // Exclude shop-level field from NS table
-    await prisma.notificationSettings.upsert({
+    await prisma.NotificationSetting.upsert({
       where: { shopId: shopRecord.id },
       create: { shopId: shopRecord.id, ...notificationSpecificData },
       update: notificationSpecificData,

--- a/app/routes/webhooks.app.uninstalled.tsx
+++ b/app/routes/webhooks.app.uninstalled.tsx
@@ -33,7 +33,7 @@ export async function action({ request }: ActionFunctionArgs) {
         console.log(`Shop data deleted for ${shop} due to app uninstall.`);
 
         // Explicitly delete sessions associated with the shop
-        await prisma.session.deleteMany({ where: { shop: shop } });
+        await prisma.session.deleteMany({ where: { shop: { shop: shop } } });
         console.log(`Sessions deleted for ${shop}.`);
 
       } else {

--- a/app/services/ai.server.ts
+++ b/app/services/ai.server.ts
@@ -100,7 +100,7 @@ export async function getAiChatResponse(userQuery: string, shopId: string): Prom
 
   const shop = await prisma.shop.findUnique({
     where: { id: shopId },
-    include: { notificationSettings: true }
+    include: { NotificationSettings: true }
   });
   if (!shop) {
     console.error(`Shop not found for ID: ${shopId} in getAiChatResponse.`);

--- a/app/services/inventory.service.ts
+++ b/app/services/inventory.service.ts
@@ -30,10 +30,10 @@ export async function updateInventoryQuantityInShopifyAndDB(
   // 2. --- Get Data from Your Database ---
   const variant = await prisma.variant.findUnique({
     where: { id: variantId },
-    select: { shopifyInventoryItemId: true, sku: true, productId: true },
+    select: { inventoryItemId: true, sku: true, productId: true },
   });
 
-  if (!variant?.shopifyInventoryItemId) {
+  if (!variant?.inventoryItemId) {
     return { success: false, error: `Variant (ID: ${variantId}, SKU: ${variant?.sku || 'Unknown'}) is not linked to a Shopify Inventory Item.` };
   }
   if (!variant.productId) {
@@ -42,7 +42,7 @@ export async function updateInventoryQuantityInShopifyAndDB(
 
   // 3. --- Get Authenticated Shopify Client ---
   const offlineSessionRecord = await prisma.session.findFirst({
-    where: { shop: shopDomain, isOnline: false, accessToken: { not: null } },
+    where: { shop: { shop: shopDomain }, isOnline: false, accessToken: { not: null } },
     orderBy: { expires: 'desc' },
   });
 
@@ -74,7 +74,7 @@ export async function updateInventoryQuantityInShopifyAndDB(
     input: {
       reason: "correction",
       setQuantities: [{
-        inventoryItemId: variant.shopifyInventoryItemId,
+        inventoryItemId: variant.inventoryItemId,
         locationId: shopifyLocationGid,
         quantity: newQuantity,
       }],


### PR DESCRIPTION
Corrected various Prisma queries across the application to align with the existing `schema.prisma` definitions.

Changes include:
- Corrected relation name casing (e.g., `notificationSettings` to `NotificationSettings`).
- Corrected model naming in Prisma client calls (e.g., `prisma.notificationSettings` to `prisma.NotificationSetting`).
- Corrected field naming (e.g., `shopifyInventoryItemId` to `inventoryItemId` in Variant queries).
- Adjusted query structure for filtering on related fields (e.g., `Session` queries filtering by `Shop` domain).