### PR TITLE
fix: Add @vercel/remix dependency and enable Vercel preset

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "@shopify/api-codegen-preset": "^1.1.1",
     "@shopify/cli": "^3.59.0",
     "@types/eslint": "^9.6.1",
+    "@vercel/remix": "^2.9.2",
     "@types/node": "^22.2.0",
     "@types/react": "^18.2.31",
     "@types/react-dom": "^18.2.14",


### PR DESCRIPTION
This commit addresses a build failure where the `@vercel/remix` package was missing after adding the `vercelPreset()` to the Vite configuration.

Changes:
- Added `@vercel/remix: ^2.9.2` to `devDependencies` in `package.json`.
- Ensured `vercelPreset()` is correctly configured in `vite.config.ts`.

This aligns the project with recommended practices for Vercel deployments as outlined in the README.md, and should resolve the `ERR_MODULE_NOT_FOUND` for `@vercel/remix` during Vercel builds.