### PR TITLE
Changes from background composer bc-df7d6b50-dd95-4dc9-944c-f5964d578949

### DIFF
--- a/build-fix-summary.md
+++ b/build-fix-summary.md
@@ -1,0 +1,61 @@
+# Build Issues Fixed - Vercel Deployment
+
+## Issues Identified
+
+### 1. Missing @vercel/remix dependency
+**Error:**
+```
+Error [ERR_MODULE_NOT_FOUND]: Cannot find package '@vercel/remix' imported from /vercel/path0/node_modules/.vite-temp/vite.config.ts.timestamp-1750985580616-9f550baf74b47.mjs
+```
+
+**Cause:** The `vite.config.ts` file was importing `vercelPreset` from `@vercel/remix/vite`, but the `@vercel/remix` package was not installed in the project dependencies.
+
+**Solution:** Added `@vercel/remix` version 2.16.7 to the `package.json` dependencies.
+
+### 2. Peer dependency conflict
+**Error:**
+```
+npm error ERESOLVE could not resolve
+npm error Could not resolve dependency: @vercel/remix@"^2.16.1" from the root project
+npm error Conflicting peer dependency: @remix-run/dev@2.16.7
+```
+
+**Cause:** Version mismatch between @vercel/remix (requires @remix-run/dev@2.16.7) and the project's @remix-run/dev@2.16.8.
+
+**Solution:** 
+1. Updated @vercel/remix to exact version 2.16.7 
+2. Used `--legacy-peer-deps` flag for npm install
+3. Updated `vercel.json` to use `--legacy-peer-deps` during Vercel deployment
+
+## Changes Made
+
+### 1. package.json
+```diff
+  "dependencies": {
+    "@shopify/shopify-app-session-storage-prisma": "^6.0.0",
++   "@vercel/remix": "2.16.7",
+    "csv-stringify": "^6.5.2",
+```
+
+### 2. vercel.json
+```diff
+-   "installCommand": "npm install",
++   "installCommand": "npm install --legacy-peer-deps",
+```
+
+## Verification
+
+✅ **Build Test Passed:** Successfully ran `npx vite build --mode test` which completed without errors
+✅ **Dependencies Installed:** All packages installed successfully with `npm install --legacy-peer-deps`
+✅ **Vercel Configuration Updated:** Deploy configuration updated to handle peer dependency conflicts
+
+## Security Notes
+
+- 7 moderate security vulnerabilities remain due to peer dependency conflicts
+- These cannot be auto-fixed without resolving the @vercel/remix version mismatch
+- The vulnerabilities are primarily in dev dependencies and don't affect production security
+- Monitor for updates to @vercel/remix that support newer Remix versions
+
+## Next Steps
+
+The build should now work successfully on Vercel. The main issue was the missing `@vercel/remix` dependency which is required for the Vercel deployment preset used in `vite.config.ts`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "@shopify/polaris": "^12.0.0",
         "@shopify/shopify-app-remix": "^3.7.0",
         "@shopify/shopify-app-session-storage-prisma": "^6.0.0",
+        "@vercel/remix": "2.16.7",
         "csv-stringify": "^6.5.2",
         "isbot": "^5.1.0",
         "react": "^18.2.0",
@@ -3429,7 +3430,6 @@
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
       "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@nodelib/fs.stat": "2.0.5",
@@ -3443,7 +3443,6 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
       "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 8"
@@ -3453,7 +3452,6 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
       "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@nodelib/fs.scandir": "2.1.5",
@@ -3901,6 +3899,7 @@
       "version": "6.10.1",
       "resolved": "https://registry.npmjs.org/@prisma/config/-/config-6.10.1.tgz",
       "integrity": "sha512-kz4/bnqrOrzWo8KzYguN0cden4CzLJJ+2VSpKtF8utHS3l1JS0Lhv6BLwpOX6X9yNreTbZQZwewb+/BMPDCIYQ==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "jiti": "2.4.2"
@@ -3910,6 +3909,7 @@
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.4.2.tgz",
       "integrity": "sha512-rg9zJN+G4n2nfJl5MW3BMygZX56zKPNVEYYqq7adpmMh4Jn2QNEwhvQlFy6jPVdcod7txZtKHWnyZiA3a0zP7A==",
+      "dev": true,
       "license": "MIT",
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
@@ -3919,12 +3919,14 @@
       "version": "6.10.1",
       "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-6.10.1.tgz",
       "integrity": "sha512-k2YT53cWxv9OLjW4zSYTZ6Z7j0gPfCzcr2Mj99qsuvlxr8WAKSZ2NcSR0zLf/mP4oxnYG842IMj3utTgcd7CaA==",
+      "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/@prisma/engines": {
       "version": "6.10.1",
       "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-6.10.1.tgz",
       "integrity": "sha512-Q07P5rS2iPwk2IQr/rUQJ42tHjpPyFcbiH7PXZlV81Ryr9NYIgdxcUrwgVOWVm5T7ap02C0dNd1dpnNcSWig8A==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -3938,12 +3940,14 @@
       "version": "6.10.1-1.9b628578b3b7cae625e8c927178f15a170e74a9c",
       "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-6.10.1-1.9b628578b3b7cae625e8c927178f15a170e74a9c.tgz",
       "integrity": "sha512-ZJFTsEqapiTYVzXya6TUKYDFnSWCNegfUiG5ik9fleQva5Sk3DNyyUi7X1+0ZxWFHwHDr6BZV5Vm+iwP+LlciA==",
+      "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/@prisma/fetch-engine": {
       "version": "6.10.1",
       "resolved": "https://registry.npmjs.org/@prisma/fetch-engine/-/fetch-engine-6.10.1.tgz",
       "integrity": "sha512-clmbG/Jgmrc/n6Y77QcBmAUlq9LrwI9Dbgy4pq5jeEARBpRCWJDJ7PWW1P8p0LfFU0i5fsyO7FqRzRB8mkdS4g==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@prisma/debug": "6.10.1",
@@ -3955,6 +3959,7 @@
       "version": "6.10.1",
       "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-6.10.1.tgz",
       "integrity": "sha512-4CY5ndKylcsce9Mv+VWp5obbR2/86SHOLVV053pwIkhVtT9C9A83yqiqI/5kJM9T1v1u1qco/bYjDKycmei9HA==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@prisma/debug": "6.10.1"
@@ -4209,6 +4214,7 @@
       "version": "2.16.8",
       "resolved": "https://registry.npmjs.org/@remix-run/route-config/-/route-config-2.16.8.tgz",
       "integrity": "sha512-YEhm2N9LIyBtGNdo6efbFCxmLHG5qdQlYyoMZdR5CaLAMICpdXr3It12xft+SoQiNL6ALnEHM9oiisZijvFZcQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "lodash": "^4.17.21"
@@ -5312,6 +5318,18 @@
         "node": ">=12"
       }
     },
+    "node_modules/@ts-morph/common": {
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/@ts-morph/common/-/common-0.11.1.tgz",
+      "integrity": "sha512-7hWZS0NRpEsNV8vWJzg7FEz6V8MaLNeJOmwmghqUXTpzk16V1LLZhdo+4QvE/+zv4cVci0OviuJFnqhEfoV3+g==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-glob": "^3.2.7",
+        "minimatch": "^3.0.4",
+        "mkdirp": "^1.0.4",
+        "path-browserify": "^1.0.1"
+      }
+    },
     "node_modules/@tybys/wasm-util": {
       "version": "0.9.0",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.9.0.tgz",
@@ -5472,7 +5490,6 @@
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/json5": {
@@ -6625,6 +6642,69 @@
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/@vanilla-extract/private/-/private-1.0.9.tgz",
       "integrity": "sha512-gT2jbfZuaaCLrAxwXbRgIhGhcXbRZCG3v4TTUnjw0EJ7ArdBRxkq4msNJkbuRkCgfIK5ATmprB5t9ljvLeFDEA==",
+      "license": "MIT"
+    },
+    "node_modules/@vercel/remix": {
+      "version": "2.16.7",
+      "resolved": "https://registry.npmjs.org/@vercel/remix/-/remix-2.16.7.tgz",
+      "integrity": "sha512-lQ7GdUO0ilX5eqIC4Wwewo5coAvacZzZrirr46BRwCp71jFqLscsruLqd6RI8s55cZWsXFZsIuOIQhcYUiL/3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@vercel/static-config": "3.0.0",
+        "isbot": "^3.6.8",
+        "ts-morph": "12.0.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "@remix-run/dev": "2.16.7",
+        "@remix-run/node": "2.16.7",
+        "@remix-run/server-runtime": "2.16.7",
+        "react": "*",
+        "react-dom": "*"
+      }
+    },
+    "node_modules/@vercel/remix/node_modules/isbot": {
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/isbot/-/isbot-3.8.0.tgz",
+      "integrity": "sha512-vne1mzQUTR+qsMLeCBL9+/tgnDXRyc2pygLGl/WsgA+EZKIiB5Ehu0CiVTHIIk30zhJ24uGz4M5Ppse37aR0Hg==",
+      "license": "Unlicense",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@vercel/static-config": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@vercel/static-config/-/static-config-3.0.0.tgz",
+      "integrity": "sha512-2qtvcBJ1bGY0dYGYh3iM7yGKkk971FujLEDXzuW5wcZsPr1GSEjO/w2iSr3qve6nDDtBImsGoDEnus5FI4+fIw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "ajv": "8.6.3",
+        "json-schema-to-ts": "1.6.4",
+        "ts-morph": "12.0.0"
+      }
+    },
+    "node_modules/@vercel/static-config/node_modules/ajv": {
+      "version": "8.6.3",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.6.3.tgz",
+      "integrity": "sha512-SMJOdDP6LqTkD0Uq8qLi+gMwSt0imXLSV080qFVwJCpH9U6Mb+SUGHAXM0KNbcBPguytWyvFxcHgMLe2D2XSpw==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/@vercel/static-config/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "license": "MIT"
     },
     "node_modules/@web3-storage/multipart-parser": {
@@ -7928,6 +8008,12 @@
         "iojs": ">= 1.0.0",
         "node": ">= 0.12.0"
       }
+    },
+    "node_modules/code-block-writer": {
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/code-block-writer/-/code-block-writer-10.1.1.tgz",
+      "integrity": "sha512-67ueh2IRGst/51p0n6FvPrnRjAGHY5F8xdjkgrYE7DDzpJe6qA07RYQ9VcoUeo5ATOjSOiWpSL3SWBRRbempMw==",
+      "license": "MIT"
     },
     "node_modules/collect-v8-coverage": {
       "version": "1.0.2",
@@ -10055,14 +10141,12 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-glob": {
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
       "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@nodelib/fs.stat": "^2.0.2",
@@ -10093,7 +10177,6 @@
       "version": "1.19.1",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.19.1.tgz",
       "integrity": "sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "reusify": "^1.0.4"
@@ -13029,7 +13112,7 @@
       "version": "1.21.7",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "bin": {
         "jiti": "bin/jiti.js"
@@ -13088,6 +13171,16 @@
       "license": "MIT",
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/json-schema-to-ts": {
+      "version": "1.6.4",
+      "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-1.6.4.tgz",
+      "integrity": "sha512-pR4yQ9DHz6itqswtHCm26mw45FSNfQ9rEQjosaZErhn5J3J2sIViQiz8rDaezjKAhFGpmsoczYVBgGHzFw/stA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/json-schema": "^7.0.6",
+        "ts-toolbelt": "^6.15.5"
       }
     },
     "node_modules/json-schema-traverse": {
@@ -13865,7 +13958,6 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
       "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 8"
@@ -14514,7 +14606,6 @@
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
       "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "braces": "^3.0.3",
@@ -15523,6 +15614,12 @@
         "tslib": "^2.0.3"
       }
     },
+    "node_modules/path-browserify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
+      "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==",
+      "license": "MIT"
+    },
     "node_modules/path-case": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/path-case/-/path-case-3.0.4.tgz",
@@ -16038,6 +16135,7 @@
       "version": "6.10.1",
       "resolved": "https://registry.npmjs.org/prisma/-/prisma-6.10.1.tgz",
       "integrity": "sha512-khhlC/G49E4+uyA3T3H5PRBut486HD2bDqE2+rvkU0pwk9IAqGFacLFUyIx9Uw+W2eCtf6XGwsp+/strUwMNPw==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -16168,7 +16266,6 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -16226,7 +16323,6 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
       "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -16577,6 +16673,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/require-like": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/require-like/-/require-like-0.1.2.tgz",
@@ -16684,7 +16789,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
       "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "iojs": ">=1.0.0",
@@ -16815,7 +16919,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
       "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -18174,6 +18277,22 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/ts-morph": {
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/ts-morph/-/ts-morph-12.0.0.tgz",
+      "integrity": "sha512-VHC8XgU2fFW7yO1f/b3mxKDje1vmyzFXHWzOYmKEkCEwcLjDtbdLgBQviqj4ZwP4MJkQtRo6Ha2I29lq/B+VxA==",
+      "license": "MIT",
+      "dependencies": {
+        "@ts-morph/common": "~0.11.0",
+        "code-block-writer": "^10.1.1"
+      }
+    },
+    "node_modules/ts-toolbelt": {
+      "version": "6.15.5",
+      "resolved": "https://registry.npmjs.org/ts-toolbelt/-/ts-toolbelt-6.15.5.tgz",
+      "integrity": "sha512-FZIXf1ksVyLcfr7M317jbB67XFJhOO1YqdTcuGaq9q5jLUoTikukZ+98TPjKiP2jC5CgmYdWWYs0s2nLSU0/1A==",
+      "license": "Apache-2.0"
+    },
     "node_modules/tsconfck": {
       "version": "3.1.6",
       "resolved": "https://registry.npmjs.org/tsconfck/-/tsconfck-3.1.6.tgz",
@@ -18374,7 +18493,7 @@
       "version": "5.8.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -18754,7 +18873,6 @@
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
       "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
-      "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "@shopify/polaris": "^12.0.0",
     "@shopify/shopify-app-remix": "^3.7.0",
     "@shopify/shopify-app-session-storage-prisma": "^6.0.0",
+    "@vercel/remix": "2.16.7",
     "csv-stringify": "^6.5.2",
     "isbot": "^5.1.0",
     "react": "^18.2.0",

--- a/vercel.json
+++ b/vercel.json
@@ -8,7 +8,7 @@
   "buildCommand": "npm run build",
   "outputDirectory": "build/client",
   "framework": "remix",
-  "installCommand": "npm install",
+  "installCommand": "npm install --legacy-peer-deps",
   "devCommand": "npm run dev"
 }
 


### PR DESCRIPTION
Add `@vercel/remix` dependency and update Vercel build configuration to fix deployment errors.

The build was failing because `@vercel/remix` was missing from dependencies. After adding it, peer dependency conflicts arose, which are now resolved by using `--legacy-peer-deps` for installation in the Vercel build environment.