### PR TITLE
Develop Shopify app with inventory management

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "@shopify/polaris": "^12.0.0",
     "@shopify/shopify-app-remix": "^3.7.0",
     "@shopify/shopify-app-session-storage-prisma": "^6.0.0",
+    "@vercel/remix": "^2.16.1",
     "csv-stringify": "^6.5.2",
     "isbot": "^5.1.0",
     "react": "^18.2.0",


### PR DESCRIPTION
Add `@vercel/remix` dependency to resolve build errors during Vercel deployment.

The build logs indicated an `ERR_MODULE_NOT_FOUND` for `@vercel/remix`, which was being imported by `vite.config.ts` but was missing from `package.json`. Adding this dependency ensures the Vercel preset for Remix can be properly resolved.